### PR TITLE
Added support for null checks in the Queryable.

### DIFF
--- a/src/InfoBridge.SuperLinq.Core/LinqProvider/RestrictionExpressionTreeVisitor.cs
+++ b/src/InfoBridge.SuperLinq.Core/LinqProvider/RestrictionExpressionTreeVisitor.cs
@@ -89,7 +89,13 @@ namespace InfoBridge.SuperLinq.Core.LinqProvider
             }
             else if (ExpressionTypeMap.OperatorMap.ContainsKey(expression.NodeType))
             {
-                _current.Operator = ExpressionTypeMap.OperatorMap[expression.NodeType];
+                // Check if this should be a null operator, else choose the mapped operator
+                if (expression.NodeType == ExpressionType.Equal && (
+                    (expression.Left is ConstantExpression && (expression.Left as ConstantExpression).Value == null) ||
+                    (expression.Right is ConstantExpression && (expression.Right as ConstantExpression).Value == null)))
+                    _current.Operator = EOperator.IsNull;
+                else
+                    _current.Operator = ExpressionTypeMap.OperatorMap[expression.NodeType];
             }
             else
             {

--- a/src/InfoBridge.SuperLinq.Core/QueryBuilders/EOperator.cs
+++ b/src/InfoBridge.SuperLinq.Core/QueryBuilders/EOperator.cs
@@ -24,6 +24,7 @@ namespace InfoBridge.SuperLinq.Core.QueryBuilders
         Is,
         NotBegins,
         IsNot,
-        NotContains
+        NotContains,
+        IsNull
     }
 }

--- a/tests/InfoBridge.SuperLinq.Tests.Unit/Helpers/TestPerson.cs
+++ b/tests/InfoBridge.SuperLinq.Tests.Unit/Helpers/TestPerson.cs
@@ -28,6 +28,9 @@ namespace InfoBridge.SuperLinq.Tests.Unit.Helpers
 
         [ColumnInfo("opt_in")]
         public int OptIn { get; set; }
+
+        [ColumnInfo("nullableInt")]
+        public int? NullableInt { get; set; }
     }
 }
 

--- a/tests/InfoBridge.SuperLinq.Tests.Unit/QueryableTests.cs
+++ b/tests/InfoBridge.SuperLinq.Tests.Unit/QueryableTests.cs
@@ -193,6 +193,54 @@ namespace InfoBridge.SuperLinq.Tests.Unit
             Assert.Equal("testperson.id", orderBy[1].Name);
             Assert.Equal(OrderBySortType.DESC, orderBy[1].Direction);
         }
+        [Fact]
+        public void TestNull1()
+        {
+            var manager = SetupManager<TestPerson>();
+            var q = new Queryable<TestPerson>(CreateExecutor(manager));
+            var results = q.Where(x => x.Email == null).ToList();
+            var restrictions = manager.RestrictionBuilder.GetRestrictions();
+
+            Assert.Equal(1, restrictions.Count);
+
+            Assert.Equal("testperson.email", restrictions[0].Name);
+            Assert.Equal("isnull", restrictions[0].Operator);
+            Assert.Null(restrictions[0].Values);
+        }
+
+        [Fact]
+        public void TestNull2()
+        {
+            var manager = SetupManager<TestPerson>();
+            var q = new Queryable<TestPerson>(CreateExecutor(manager));
+            var results = q.Where(x => null == x.Email).ToList();
+            var restrictions = manager.RestrictionBuilder.GetRestrictions();
+
+            Assert.Equal(1, restrictions.Count);
+
+            Assert.Equal("testperson.email", restrictions[0].Name);
+            Assert.Equal("isnull", restrictions[0].Operator);
+            Assert.Null(restrictions[0].Values);
+        }
+
+        [Fact]
+        public void TestNull3()
+        {
+            var manager = SetupManager<TestPerson>();
+            var q = new Queryable<TestPerson>(CreateExecutor(manager));
+            var results = q.Where(x => null == x.Email && x.NullableInt == null).ToList();
+            var restrictions = manager.RestrictionBuilder.GetRestrictions();
+
+            Assert.Equal(2, restrictions.Count);
+
+
+            Assert.Equal("testperson.email", restrictions[0].Name);
+            Assert.Equal("isnull", restrictions[0].Operator);
+            Assert.Null(restrictions[0].Values);
+            Assert.Equal("testperson.nullableInt", restrictions[1].Name);
+            Assert.Equal("isnull", restrictions[1].Operator);
+            Assert.Null(restrictions[1].Values);
+        }
 
         private MockArchiveManager<T> SetupManager<T>()
         {


### PR DESCRIPTION
This means that checks like this "x.name == null" in the where are supported.